### PR TITLE
feat(forkable): bound reversible buffer (WithMaxReversibleBlocks) to fail fast on LIB stall (B1)

### DIFF
--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -44,6 +44,10 @@ type Forkable struct {
 
 	lastLongestChain []*Block
 	libnumGetter     LIBNumGetter
+
+	// maxReversibleBlocks, when > 0, caps the ForkDB reversible buffer; exceeding it
+	// (a LIB stall) makes ProcessBlock fail fast for a clean restart. See WithMaxReversibleBlocks.
+	maxReversibleBlocks int
 }
 
 // custom way to extract LIB num from a block and forkDB. forkDB may be nil.
@@ -273,6 +277,17 @@ func (p *Forkable) ProcessBlock(blk *bstream.Block, obj interface{}) error {
 	previousRef := bstream.NewBlockRef(blk.PreviousID(), blk.Num()-1)
 	if exists := p.forkDB.AddLink(blk, previousRef, ppBlk); exists {
 		return nil
+	}
+
+	// Bound the reversible buffer. AddLink just grew it; eviction (MoveLIB) only
+	// happens later in this method, and only when LIB advances — so on a LIB stall
+	// the buffer grows unbounded (the gateCursor blowup's twin). Fail fast here so
+	// the consumer restarts cleanly from its cursor instead of OOMing. Opt-in; tracks
+	// the real reversible window, so it only fires on a genuine stall.
+	if p.maxReversibleBlocks > 0 {
+		if n := p.forkDB.ReversibleBlockCount(); n > p.maxReversibleBlocks {
+			return fmt.Errorf("forkable reversible buffer exceeded cap of %d blocks (have %d): LIB likely stalled at %d while head is at %d; failing fast for a clean restart", p.maxReversibleBlocks, n, p.forkDB.LIBNum(), blk.Num())
+		}
 	}
 
 	if !p.forkDB.HasLIB() { // always skip processing until LIB is set

--- a/forkable/forkable.go
+++ b/forkable/forkable.go
@@ -285,8 +285,20 @@ func (p *Forkable) ProcessBlock(blk *bstream.Block, obj interface{}) error {
 	// the consumer restarts cleanly from its cursor instead of OOMing. Opt-in; tracks
 	// the real reversible window, so it only fires on a genuine stall.
 	if p.maxReversibleBlocks > 0 {
-		if n := p.forkDB.ReversibleBlockCount(); n > p.maxReversibleBlocks {
+		n := p.forkDB.ReversibleBlockCount()
+		if n > p.maxReversibleBlocks {
 			return fmt.Errorf("forkable reversible buffer exceeded cap of %d blocks (have %d): LIB likely stalled at %d while head is at %d; failing fast for a clean restart", p.maxReversibleBlocks, n, p.forkDB.LIBNum(), blk.Num())
+		}
+		// Soft alert: the buffer should track the small head-minus-LIB window. Crossing
+		// half the cap means it is growing abnormally (LIB likely stalling). Warn early
+		// (sampled) so SREs see it well before the hard fail-fast at the cap.
+		if n > p.maxReversibleBlocks/2 && blk.Number%600 == 0 {
+			p.logger.Warn("forkable reversible buffer is growing abnormally — LIB may be stalling (will fail fast at the cap to avoid OOM)",
+				zap.Int("reversible_blocks", n),
+				zap.Int("cap", p.maxReversibleBlocks),
+				zap.Uint64("lib_num", p.forkDB.LIBNum()),
+				zap.Uint64("head_num", blk.Num()),
+			)
 		}
 	}
 

--- a/forkable/forkable_maxreversible_test.go
+++ b/forkable/forkable_maxreversible_test.go
@@ -1,0 +1,70 @@
+// Copyright 2019 dfuse Platform Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package forkable
+
+import (
+	"testing"
+
+	"github.com/streamingfast/bstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestForkable_MaxReversibleBlocks reproduces the unbounded-reversible-buffer growth
+// when chain LIB stalls (irreversibility stops advancing while head keeps moving).
+// MoveLIB is the only eviction path, and ProcessBlock returns early (before MoveLIB)
+// while LIB doesn't advance, so ForkDB.objects/links grow without bound -> OOM. This
+// is the structural twin of the deleted gateCursor blowup. The cap makes the forkable
+// fail fast (clean consumer restart) instead.
+func TestForkable_MaxReversibleBlocks(t *testing.T) {
+	prev := bstream.GetProtocolFirstStreamableBlock
+	bstream.GetProtocolFirstStreamableBlock = 2
+	defer func() { bstream.GetProtocolFirstStreamableBlock = prev }()
+
+	// Blocks 1..3 advance LIB to 2 normally; from block 4 on, LIB stalls at 2 while
+	// head keeps advancing -> the reversible buffer grows every block.
+	stalled := func() []*bstream.Block {
+		return []*bstream.Block{
+			bTestBlockWithLIBNum("00000001a", "", 0),
+			bTestBlockWithLIBNum("00000002a", "00000001a", 1),
+			bTestBlockWithLIBNum("00000003a", "00000002a", 2),
+			bTestBlockWithLIBNum("00000004a", "00000003a", 2),
+			bTestBlockWithLIBNum("00000005a", "00000004a", 2),
+			bTestBlockWithLIBNum("00000006a", "00000005a", 2),
+			bTestBlockWithLIBNum("00000007a", "00000006a", 2),
+			bTestBlockWithLIBNum("00000008a", "00000007a", 2),
+		}
+	}
+
+	t.Run("control: no cap -> buffer grows unbounded, no error", func(t *testing.T) {
+		fap := New(newTestForkableSink(nil, nil))
+		for _, b := range stalled() {
+			require.NoError(t, fap.ProcessBlock(b, b.ID()))
+		}
+		require.Greater(t, fap.forkDB.ReversibleBlockCount(), 3,
+			"the LIB stall should have grown the reversible buffer past 3")
+	})
+
+	t.Run("with cap: fails fast once the buffer exceeds the cap", func(t *testing.T) {
+		fap := New(newTestForkableSink(nil, nil), WithMaxReversibleBlocks(3))
+		var err error
+		for _, b := range stalled() {
+			if err = fap.ProcessBlock(b, b.ID()); err != nil {
+				break
+			}
+		}
+		require.Error(t, err, "the forkable must fail fast when the reversible buffer exceeds the cap")
+		require.Contains(t, err.Error(), "reversible buffer")
+	})
+}

--- a/forkable/forkdb.go
+++ b/forkable/forkdb.go
@@ -184,6 +184,17 @@ func (f *ForkDB) Exists(blockID string) bool {
 	return f.links[blockID] != ""
 }
 
+// ReversibleBlockCount returns the number of blocks currently held in the
+// reversible buffer (links not yet purged below LIB). Eviction is LIB-driven
+// (MoveLIB) only, so this grows unbounded if LIB stalls — callers can use it to
+// bound memory (see Forkable's WithMaxReversibleBlocks).
+func (f *ForkDB) ReversibleBlockCount() int {
+	f.linksLock.Lock()
+	defer f.linksLock.Unlock()
+
+	return len(f.links)
+}
+
 func (f *ForkDB) AddLink(blockRef, previousRef bstream.BlockRef, obj interface{}) (exists bool) {
 	f.linksLock.Lock()
 	defer f.linksLock.Unlock()

--- a/forkable/options.go
+++ b/forkable/options.go
@@ -36,6 +36,20 @@ func WithLogger(logger *zap.Logger) Option {
 	}
 }
 
+// WithMaxReversibleBlocks bounds the ForkDB reversible buffer. Eviction is
+// LIB-driven (MoveLIB) only, so if chain LIB stalls while head keeps advancing
+// the buffer grows without bound (OOM — the structural twin of the deleted
+// gateCursor blowup). When the buffer exceeds max, ProcessBlock fails fast with
+// an error so the consumer restarts cleanly from its cursor instead of OOMing.
+// 0 (the default) disables the cap. Set it far above the normal reversible
+// window (which tracks head-minus-LIB); it should only ever fire on a genuine
+// LIB stall. Consumers that pin LIB to head (RelativeLIBNumGetter) never hit it.
+func WithMaxReversibleBlocks(max int) Option {
+	return func(f *Forkable) {
+		f.maxReversibleBlocks = max
+	}
+}
+
 func WithInclusiveLIB(irreversibleBlock bstream.BlockRef) Option {
 	return func(f *Forkable) {
 		f.includeInitialLIB = true


### PR DESCRIPTION
## Problem (stability sweep B1 — `ultraOS-doc/dfuse-deep-dive/17`)

`ForkDB.objects`/`links` are evicted **only** by `MoveLIB` (LIB-driven; `forkdb.go` is the sole `delete` site). If chain **LIB stalls** (irreversibility stops advancing) while head keeps moving, the reversible buffer grows **without bound → OOM**. This is the structural twin of the deleted `gateCursor` blowup. The firehose is masked (it pins LIB to head via `RelativeLIBNumGetter`), but any consumer on **real chain LIB** has no floor.

## Fix

Opt-in cap: **`Forkable.WithMaxReversibleBlocks(max)`**. When the reversible buffer exceeds `max`, `ProcessBlock` returns an error so the consumer restarts cleanly from its cursor instead of OOMing.

**Key correctness detail:** the check runs **right after `AddLink`** (the growth point), **not** after `MoveLIB`. During a stall, `ProcessBlock` returns early at `HasNewIrreversibleSegment` (`!hasNew`) and **never reaches `MoveLIB`** — so a check placed there would never fire. (This corrects the original design sketch in doc 17.)

- `default 0 = disabled` → **existing consumers unchanged** (firehose included; zero behavior change).
- Fail-fast (not drop-oldest): dropping the oldest reversible block would corrupt the fork tree.
- Adds `ForkDB.ReversibleBlockCount()` (locked) so **direct-`ForkDB` consumers** (e.g. fluxdb's `serverForkDB`, pattern-2) can apply the same bound without the `Forkable` wrapper.

## Test
`TestForkable_MaxReversibleBlocks`:
- **control** (no cap): a simulated LIB stall grows the buffer past 3 with no error — proves the unbounded growth.
- **with cap**: `ProcessBlock` fails fast once the buffer exceeds the cap.

Full `forkable/...` suite green under `-race`; `go vet` clean.

## Activation (separate, deliberate — NOT in this PR)
This is the **mechanism** (opt-in, dormant by default). Wiring it into the exposed consumers is a per-consumer follow-up:
- **Pattern-1 (Forkable):** persistent injectors `trxdb-loader`, `tokenmeta`, `accounthist` use real chain LIB → wire `WithMaxReversibleBlocks(N)`. (eosws live subscriptions are short-lived per-request — lower priority.)
- **Pattern-2 (direct ForkDB):** fluxdb `serverForkDB` (statedb-inject) → add a `ReversibleBlockCount()` check after its `AddLink`.

Each needs a chosen ceiling (far above the normal head−LIB window) + a dfuse-eosio bstream re-pin. Tracked in doc 17 §4b.